### PR TITLE
Fixed broken `DEPLOYMENT.md` hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ AnnotateChange can be launched quickly for local development as follows:
 
 To use AnnotateChange locally using Docker, follow the steps below. For a 
 full-fledged installation on a server, see the [deployment 
-instructions](./docs/DEPLOYMENT).
+instructions](./docs/DEPLOYMENT.md).
 
 0. Install [docker](https://docs.docker.com/get-docker/) and 
    [docker-compose](https://docs.docker.com/compose/install/).


### PR DESCRIPTION
The hyperlink to the `DEPOLYMENT.md` file results in a 404 error. This is simply because the `.md` extension was missing in the code, which I have included in this pull request.